### PR TITLE
feat: 添加 Vercel Analytics 网站分析

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -17,7 +18,10 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.ico" />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@monaco-editor/react": "^4.7.0",
 				"@radix-ui/react-dialog": "^1.1.14",
 				"@radix-ui/react-slot": "^1.2.3",
+				"@vercel/analytics": "^1.5.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"form-data": "^4.0.3",
@@ -3900,6 +3901,44 @@
 			"os": [
 				"linux"
 			]
+		},
+		"node_modules/@vercel/analytics": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmmirror.com/@vercel/analytics/-/analytics-1.5.0.tgz",
+			"integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+			"license": "MPL-2.0",
+			"peerDependencies": {
+				"@remix-run/react": "^2",
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"svelte": ">= 4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
+				"@remix-run/react": {
+					"optional": true
+				},
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/abstract-leveldown": {
 			"version": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@monaco-editor/react": "^4.7.0",
 		"@radix-ui/react-dialog": "^1.1.14",
 		"@radix-ui/react-slot": "^1.2.3",
+		"@vercel/analytics": "^1.5.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"form-data": "^4.0.3",


### PR DESCRIPTION
## 功能概述
添加 Vercel Analytics 来追踪网站访问量和页面浏览量

## 修改内容
- 安装 `@vercel/analytics` 包
- 在根布局 `app/layout.tsx` 中集成 Analytics 组件
- 支持实时访问统计和用户行为分析

## 测试结果
- ✅ 构建测试通过
- ✅ 所有页面正常生成
- ✅ Analytics 组件正确集成

## 部署后效果
- 网站访问量统计
- 页面浏览量追踪
- 用户行为分析
- Vercel Dashboard 数据展示

🚀 Generated with [Claude Code](https://claude.ai/code)